### PR TITLE
Add missing greenlet library

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ asyncpg = "~=0.28.0"
 python-dotenv = "~=1.0.0"
 asyncio = "~=3.4.3"
 sqlalchemy = "~=2.0.20"
+greenlet = "~=2.0.2"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b5c8b26469401fd63b056b81bcaec446c1a0e700d45d133f600c4ce2e5eff0e5"
+            "sha256": "8a0ce1e94a71c221e7dd6dfc677943b5ea94cf813c3b09388d6edc5700b99193"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -402,11 +402,11 @@
         },
         "filelock": {
             "hashes": [
-                "sha256:002740518d8aa59a26b0c76e10fb8c6e15eae825d34b6fdf670333fd7b938d81",
-                "sha256:cbb791cdea2a72f23da6ac5b5269ab0a0d161e9ef0100e653b69049a7706d1ec"
+                "sha256:0ecc1dd2ec4672a10c8550a8182f1bd0c0a5088470ecd5a125e45f49472fac3d",
+                "sha256:f067e40ccc40f2b48395a80fcbd4728262fab54e232e090a4063ab804179efeb"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==3.12.2"
+            "markers": "python_version >= '3.8'",
+            "version": "==3.12.3"
         },
         "frozenlist": {
             "hashes": [
@@ -479,6 +479,7 @@
             "hashes": [
                 "sha256:03a8f4f3430c3b3ff8d10a2a86028c660355ab637cee9333d63d66b56f09d52a",
                 "sha256:0bf60faf0bc2468089bdc5edd10555bab6e85152191df713e2ab1fcc86382b5a",
+                "sha256:1087300cf9700bbf455b1b97e24db18f2f77b55302a68272c56209d5587c12d1",
                 "sha256:18a7f18b82b52ee85322d7a7874e676f34ab319b9f8cce5de06067384aa8ff43",
                 "sha256:18e98fb3de7dba1c0a852731c3070cf022d14f0d68b4c87a19cc1016f3bb8b33",
                 "sha256:1a819eef4b0e0b96bb0d98d797bef17dc1b4a10e8d7446be32d1da33e095dbb8",
@@ -504,6 +505,7 @@
                 "sha256:76ae285c8104046b3a7f06b42f29c7b73f77683df18c49ab5af7983994c2dd91",
                 "sha256:7cafd1208fdbe93b67c7086876f061f660cfddc44f404279c1585bbf3cdc64c5",
                 "sha256:7efde645ca1cc441d6dc4b48c0f7101e8d86b54c8530141b09fd31cef5149ec9",
+                "sha256:8512a0c38cfd4e66a858ddd1b17705587900dd760c6003998e9472b77b56d417",
                 "sha256:88d9ab96491d38a5ab7c56dd7a3cc37d83336ecc564e4e8816dbed12e5aaefc8",
                 "sha256:8eab883b3b2a38cc1e050819ef06a7e6344d4a990d24d45bc6f2cf959045a45b",
                 "sha256:910841381caba4f744a44bf81bfd573c94e10b3045ee00de0cbf436fe50673a6",
@@ -527,8 +529,10 @@
                 "sha256:c9c59a2120b55788e800d82dfa99b9e156ff8f2227f07c5e3012a45a399620b7",
                 "sha256:cd021c754b162c0fb55ad5d6b9d960db667faad0fa2ff25bb6e1301b0b6e6a75",
                 "sha256:d27ec7509b9c18b6d73f2f5ede2622441de812e7b1a80bbd446cb0633bd3d5ae",
+                "sha256:d4606a527e30548153be1a9f155f4e283d109ffba663a15856089fb55f933e47",
                 "sha256:d5508f0b173e6aa47273bdc0a0b5ba055b59662ba7c7ee5119528f466585526b",
                 "sha256:d75209eed723105f9596807495d58d10b3470fa6732dd6756595e89925ce2470",
+                "sha256:d967650d3f56af314b72df7089d96cda1083a7fc2da05b375d2bc48c82ab3f3c",
                 "sha256:db1a39669102a1d8d12b57de2bb7e2ec9066a6f2b3da35ae511ff93b01b5d564",
                 "sha256:dbfcfc0218093a19c252ca8eb9aee3d29cfdcb586df21049b9d777fd32c14fd9",
                 "sha256:e0f72c9ddb8cd28532185f54cc1453f2c16fb417a08b53a855c4e6a418edd099",
@@ -538,7 +542,8 @@
                 "sha256:f82d4d717d8ef19188687aa32b8363e96062911e63ba22a0cff7802a8e58e5f1",
                 "sha256:fc3a569657468b6f3fb60587e48356fe512c1754ca05a564f11366ac9e306526"
             ],
-            "markers": "platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))",
+            "index": "pypi",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==2.0.2"
         },
         "hyperlink": {
@@ -862,12 +867,12 @@
         },
         "scrapy": {
             "hashes": [
-                "sha256:4e16a33fc8c03a58bdf4e8d4bdca1f867354eac69ccf573658c7ff34fa0cae39",
-                "sha256:e6a44469eb4846a44f6c573f7d4110afbf8f4ed87775c22b4b04110924581d13"
+                "sha256:0b2f99d297f32112ae7979f50b9942a5f55b09b821f1c3afb0bed950f6a1f5a7",
+                "sha256:91d67875fbb537607b07e31363445718a3532b544e6e2b4baf8a042b21a1d10f"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==2.10.0"
+            "version": "==2.10.1"
         },
         "service-identity": {
             "hashes": [


### PR DESCRIPTION
Without greenlet, scrapy failed with following error:

```
pipenv run scrapy crawl vnexpress -a days_ago=1 
Loading .env environment variables...
2023-09-05 10:37:46 [scrapy.utils.log] INFO: Scrapy 2.10.0 started (bot: news_crawler)
2023-09-05 10:37:46 [scrapy.utils.log] INFO: Versions: lxml 4.9.3.0, libxml2 2.9.13, cssselect 1.2.0, parsel 1.8.1, w3lib 2.1.2, Twisted 22.10.0, Python 3.10.13 (main, Sep  5 2023, 09:35:31) [Clang 14.0.3 (clang-1403.0.22.14.1)], pyOpenSSL 23.2.0 (OpenSSL 3.1.2 1 Aug 2023), cryptography 41.0.3, Platform macOS-13.5.1-arm64-arm-64bit
2023-09-05 10:37:46 [scrapy.addons] INFO: Enabled addons:
[]
2023-09-05 10:37:46 [scrapy.crawler] INFO: Overridden settings:
{'BOT_NAME': 'news_crawler',
 'COOKIES_DEBUG': True,
 'COOKIES_ENABLED': False,
 'FEED_EXPORT_ENCODING': 'utf-8',
 'NEWSPIDER_MODULE': 'news_crawler.spiders',
 'REQUEST_FINGERPRINTER_IMPLEMENTATION': '2.7',
 'ROBOTSTXT_OBEY': True,
 'SPIDER_MODULES': ['news_crawler.spiders'],
 'TWISTED_REACTOR': 'twisted.internet.asyncioreactor.AsyncioSelectorReactor'}
2023-09-05 10:37:46 [asyncio] DEBUG: Using selector: KqueueSelector
2023-09-05 10:37:46 [scrapy.utils.log] DEBUG: Using reactor: twisted.internet.asyncioreactor.AsyncioSelectorReactor
2023-09-05 10:37:46 [scrapy.utils.log] DEBUG: Using asyncio event loop: asyncio.unix_events._UnixSelectorEventLoop
2023-09-05 10:37:46 [scrapy.extensions.telnet] INFO: Telnet Password: ce3c9676f5f4552c
2023-09-05 10:37:46 [scrapy.middleware] INFO: Enabled extensions:
['scrapy.extensions.corestats.CoreStats',
 'scrapy.extensions.telnet.TelnetConsole',
 'scrapy.extensions.memusage.MemoryUsage',
 'scrapy.extensions.logstats.LogStats']
2023-09-05 10:37:46 [vnexpress] DEBUG: [init][vnexpress] days_ago = 1 is of <class 'str'>. Converting...
2023-09-05 10:37:46 [vnexpress] DEBUG: Crawling from Sep 04 to Sep 05
2023-09-05 10:37:46 [scrapy.middleware] INFO: Enabled downloader middlewares:
['scrapy.downloadermiddlewares.robotstxt.RobotsTxtMiddleware',
 'scrapy.downloadermiddlewares.httpauth.HttpAuthMiddleware',
 'scrapy.downloadermiddlewares.downloadtimeout.DownloadTimeoutMiddleware',
 'scrapy.downloadermiddlewares.defaultheaders.DefaultHeadersMiddleware',
 'scrapy.downloadermiddlewares.useragent.UserAgentMiddleware',
 'scrapy.downloadermiddlewares.retry.RetryMiddleware',
 'scrapy.downloadermiddlewares.redirect.MetaRefreshMiddleware',
 'scrapy.downloadermiddlewares.httpcompression.HttpCompressionMiddleware',
 'scrapy.downloadermiddlewares.redirect.RedirectMiddleware',
 'scrapy.downloadermiddlewares.httpproxy.HttpProxyMiddleware',
 'scrapy.downloadermiddlewares.stats.DownloaderStats']
2023-09-05 10:37:46 [scrapy.middleware] INFO: Enabled spider middlewares:
['scrapy.spidermiddlewares.httperror.HttpErrorMiddleware',
 'scrapy.spidermiddlewares.offsite.OffsiteMiddleware',
 'scrapy.spidermiddlewares.referer.RefererMiddleware',
 'scrapy.spidermiddlewares.urllength.UrlLengthMiddleware',
 'scrapy.spidermiddlewares.depth.DepthMiddleware']
Unhandled error in Deferred:
2023-09-05 10:37:46 [twisted] CRITICAL: Unhandled error in Deferred:

Traceback (most recent call last):
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/scrapy/crawler.py", line 245, in crawl
    return self._crawl(crawler, *args, **kwargs)
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/scrapy/crawler.py", line 249, in _crawl
    d = crawler.crawl(*args, **kwargs)
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/twisted/internet/defer.py", line 1947, in unwindGenerator
    return _cancellableInlineCallbacks(gen)
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/twisted/internet/defer.py", line 1857, in _cancellableInlineCallbacks
    _inlineCallbacks(None, gen, status, _copy_context())
--- <exception caught here> ---
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/twisted/internet/defer.py", line 1697, in _inlineCallbacks
    result = context.run(gen.send, result)
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/scrapy/crawler.py", line 134, in crawl
    self.engine = self._create_engine()
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/scrapy/crawler.py", line 148, in _create_engine
    return ExecutionEngine(self, lambda _: self.stop())
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/scrapy/core/engine.py", line 99, in __init__
    self.scraper = Scraper(crawler)
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/scrapy/core/scraper.py", line 109, in __init__
    self.itemproc: ItemPipelineManager = itemproc_cls.from_crawler(crawler)
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/scrapy/middleware.py", line 67, in from_crawler
    return cls.from_settings(crawler.settings, crawler)
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/scrapy/middleware.py", line 44, in from_settings
    mw = create_instance(mwcls, settings, crawler)
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/scrapy/utils/misc.py", line 188, in create_instance
    instance = objcls.from_crawler(crawler, *args, **kwargs)
  File "/Users/favadi/code/calif/news-crawler/news_crawler/pipelines/postgres.py", line 24, in from_crawler
    postgres = cls(pg_settings.get("URI"), pg_settings.get("BUFFER_SIZE", 100))
  File "/Users/favadi/code/calif/news-crawler/news_crawler/pipelines/postgres.py", line 14, in __init__
    self.postgres = Postgres(uri=uri)
  File "/Users/favadi/code/calif/news-crawler/database/postgres.py", line 24, in __init__
    self.engine = create_async_engine(self.uri)
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/sqlalchemy/ext/asyncio/engine.py", line 117, in create_async_engine
    sync_engine = _create_engine(url, **kw)
  File "<string>", line 2, in create_engine
    
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/sqlalchemy/util/deprecations.py", line 281, in warned
    return fn(*args, **kwargs)  # type: ignore[no-any-return]
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/sqlalchemy/engine/create.py", line 706, in create_engine
    event.listen(pool, "connect", on_connect)
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/sqlalchemy/event/api.py", line 124, in listen
    _event_key(target, identifier, fn).listen(*args, **kw)
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/sqlalchemy/event/registry.py", line 310, in listen
    self.dispatch_target.dispatch._listen(self, *args, **kw)
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/sqlalchemy/event/base.py", line 178, in _listen
    return self._events._listen(event_key, **kw)
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/sqlalchemy/pool/events.py", line 94, in _listen
    event_key.base_listen(**kw)
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/sqlalchemy/event/registry.py", line 347, in base_listen
    for_modify._set_asyncio()
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/sqlalchemy/event/attr.py", line 416, in _set_asyncio
    self._exec_once_mutex = AsyncAdaptedLock()
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/sqlalchemy/util/concurrency.py", line 63, in AsyncAdaptedLock
    _not_implemented()
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/sqlalchemy/util/concurrency.py", line 43, in _not_implemented
    raise ValueError(
builtins.ValueError: the greenlet library is required to use this function. No module named 'greenlet'

2023-09-05 10:37:46 [twisted] CRITICAL: 
Traceback (most recent call last):
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/twisted/internet/defer.py", line 1697, in _inlineCallbacks
    result = context.run(gen.send, result)
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/scrapy/crawler.py", line 134, in crawl
    self.engine = self._create_engine()
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/scrapy/crawler.py", line 148, in _create_engine
    return ExecutionEngine(self, lambda _: self.stop())
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/scrapy/core/engine.py", line 99, in __init__
    self.scraper = Scraper(crawler)
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/scrapy/core/scraper.py", line 109, in __init__
    self.itemproc: ItemPipelineManager = itemproc_cls.from_crawler(crawler)
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/scrapy/middleware.py", line 67, in from_crawler
    return cls.from_settings(crawler.settings, crawler)
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/scrapy/middleware.py", line 44, in from_settings
    mw = create_instance(mwcls, settings, crawler)
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/scrapy/utils/misc.py", line 188, in create_instance
    instance = objcls.from_crawler(crawler, *args, **kwargs)
  File "/Users/favadi/code/calif/news-crawler/news_crawler/pipelines/postgres.py", line 24, in from_crawler
    postgres = cls(pg_settings.get("URI"), pg_settings.get("BUFFER_SIZE", 100))
  File "/Users/favadi/code/calif/news-crawler/news_crawler/pipelines/postgres.py", line 14, in __init__
    self.postgres = Postgres(uri=uri)
  File "/Users/favadi/code/calif/news-crawler/database/postgres.py", line 24, in __init__
    self.engine = create_async_engine(self.uri)
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/sqlalchemy/ext/asyncio/engine.py", line 117, in create_async_engine
    sync_engine = _create_engine(url, **kw)
  File "<string>", line 2, in create_engine
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/sqlalchemy/util/deprecations.py", line 281, in warned
    return fn(*args, **kwargs)  # type: ignore[no-any-return]
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/sqlalchemy/engine/create.py", line 706, in create_engine
    event.listen(pool, "connect", on_connect)
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/sqlalchemy/event/api.py", line 124, in listen
    _event_key(target, identifier, fn).listen(*args, **kw)
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/sqlalchemy/event/registry.py", line 310, in listen
    self.dispatch_target.dispatch._listen(self, *args, **kw)
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/sqlalchemy/event/base.py", line 178, in _listen
    return self._events._listen(event_key, **kw)
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/sqlalchemy/pool/events.py", line 94, in _listen
    event_key.base_listen(**kw)
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/sqlalchemy/event/registry.py", line 347, in base_listen
    for_modify._set_asyncio()
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/sqlalchemy/event/attr.py", line 416, in _set_asyncio
    self._exec_once_mutex = AsyncAdaptedLock()
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/sqlalchemy/util/concurrency.py", line 63, in AsyncAdaptedLock
    _not_implemented()
  File "/Users/favadi/.local/share/virtualenvs/news-crawler-hvuEAUN0/lib/python3.10/site-packages/sqlalchemy/util/concurrency.py", line 43, in _not_implemented
    raise ValueError(
ValueError: the greenlet library is required to use this function. No module named 'greenlet'
```

OS: macOS 13.5.1
Python version: 3.10.13